### PR TITLE
build.js: Ignore already appended files

### DIFF
--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -46,6 +46,10 @@ function main() {
 
 		for ( var j = 0; j < files.length; j ++ ){
 
+			if (buffer.indexOf('// File:' + files[ j ]) > -1) {
+				continue; // File already appended
+			}
+
 			var file = '../../' + files[ j ];
 			
 			buffer.push('// File:' + files[ j ]);


### PR DESCRIPTION
When multiple include files contain the same file, it will be appended every time.

Example:
node build.js --include common --include canvas --include css3d --include extras --include math
